### PR TITLE
Implement JWT login

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ tokio-postgres = "0.7"
 deadpool-postgres = "0.10"
 log = "0.4"
 env_logger = "0.10"
+jsonwebtoken = "9"
+chrono = { version = "0.4", features = ["serde"] }
+once_cell = "1"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ cd rust-web-demo
 - `POST /todos/{id}/toggle` - 切換待辦事項的完成狀態
 - `DELETE /todos/{id}` - 刪除待辦事項
 - `GET /test-db` - 測試數據庫連接
+- `POST /api/login` - 使用者登入並取得 JWT
+
+登入頁面可透過 `/login` 進入，所有 Todo API 需在 `Authorization` header 中附帶 `Bearer <token>`。
 
 ## 數據庫結構
 

--- a/static/app.js
+++ b/static/app.js
@@ -1,8 +1,11 @@
+const token = localStorage.getItem('token');
+if (!token) window.location.href = '/login';
+
 let todos = [];
 let currentFilter = 'all';
 
 async function fetchTodos() {
-  const res = await fetch("/todos");
+  const res = await fetch("/todos", { headers: { 'Authorization': `Bearer ${token}` } });
   todos = await res.json();
   renderTodos();
 }
@@ -72,7 +75,7 @@ async function addTodo() {
 
   await fetch("/todos", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", 'Authorization': `Bearer ${token}` },
     body: JSON.stringify({ title, done: false })
   });
 
@@ -89,12 +92,12 @@ document.getElementById("new-task").addEventListener("keypress", function(event)
 });
 
 async function toggle(id) {
-  await fetch(`/todos/${id}/toggle`, { method: "POST" });
+  await fetch(`/todos/${id}/toggle`, { method: "POST", headers: { 'Authorization': `Bearer ${token}` } });
   fetchTodos();
 }
 
 async function remove(id) {
-  await fetch(`/todos/${id}`, { method: "DELETE" });
+  await fetch(`/todos/${id}`, { method: "DELETE", headers: { 'Authorization': `Bearer ${token}` } });
   fetchTodos();
 }
 
@@ -103,7 +106,7 @@ function editTodo(todo) {
   if (newTitle && newTitle.trim() !== "") {
     fetch(`/todos/${todo.id}`, {
       method: "PUT",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", 'Authorization': `Bearer ${token}` },
       body: JSON.stringify({ title: newTitle.trim() })
     }).then(fetchTodos);
   }

--- a/static/index.html
+++ b/static/index.html
@@ -7,6 +7,11 @@
 </head>
 <body>
   <h1>Rust To-Do List</h1>
+  <script>
+    if (!localStorage.getItem('token')) {
+      window.location.href = '/login';
+    }
+  </script>
   <div class="input-section">
     <input id="new-task" placeholder="Add a new task..." />
     <button class="add" onclick="addTodo()">Add</button>

--- a/static/login.html
+++ b/static/login.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Login</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Login</h1>
+  <div class="input-section">
+    <input id="username" placeholder="Username" />
+    <input id="password" type="password" placeholder="Password" />
+    <button class="add" onclick="login()">Login</button>
+  </div>
+  <script>
+    async function login() {
+      const username = document.getElementById('username').value;
+      const password = document.getElementById('password').value;
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      });
+      if (res.ok) {
+        const data = await res.json();
+        localStorage.setItem('token', data.token);
+        window.location.href = '/';
+      } else {
+        alert('Login failed');
+      }
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new dependencies for JWT handling
- create user table and default user
- add JWT authentication middleware and login endpoint
- serve new login page
- secure todo routes with Authorization header
- document new API endpoints and login instructions

## Testing
- `cargo check` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_684595e9b6408326974809ce3d295d37