### PR TITLE
Add CI/CD shell script

### DIFF
--- a/auto_build.sh
+++ b/auto_build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 # Build new image
 docker build -t rust-demo .
 

--- a/auto_run.sh
+++ b/auto_run.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -e
+
 # Run PostgreSQL container
 docker stop rust-demo rust_postgres 2>/dev/null || true
 docker rm rust-demo rust_postgres 2>/dev/null || true
@@ -10,9 +13,11 @@ docker run -d --name rust_postgres \
     postgres:15
 
 # Run application container
-docker run --rm -p 8080:8080 \
-    -v /Users/dennis/rust/rust-web-demo/static:/app/static \
+APP_CONTAINER=$(docker run -d --rm -p 8080:8080 \
+    -v "$(pwd)/static:/app/static" \
     --name rust-demo \
     --link rust_postgres:postgres \
     -e RUST_LOG=info \
-    rust-demo
+    rust-demo)
+
+echo "Application container started with ID $APP_CONTAINER"

--- a/ci_cd.sh
+++ b/ci_cd.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build image and run containers
+./auto_build.sh
+./auto_run.sh
+
+# Ensure containers are stopped on exit
+trap 'docker stop rust-demo rust_postgres >/dev/null 2>&1 || true' EXIT
+
+# Wait for server to be ready
+for i in {1..30}; do
+    if curl -sf http://localhost:8080/test-db > /dev/null; then
+        break
+    fi
+    sleep 1
+done
+
+# Login and obtain JWT
+TOKEN=$(curl -s -X POST http://localhost:8080/api/login \
+    -H "Content-Type: application/json" \
+    -d '{"username":"admin","password":"password"}' | jq -r '.token')
+
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+    echo "Failed to retrieve auth token" >&2
+    exit 1
+fi
+
+# Test GET /todos
+curl -f -H "Authorization: Bearer $TOKEN" http://localhost:8080/todos
+
+# Test POST /todos
+ID=$(curl -s -X POST http://localhost:8080/todos \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"title":"CI Todo","done":false}' | jq -r '.id')
+
+# Test PUT /todos/{id}
+curl -f -X PUT http://localhost:8080/todos/$ID \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"title":"Updated CI Todo"}'
+
+# Test POST /todos/{id}/toggle
+curl -f -X POST http://localhost:8080/todos/$ID/toggle \
+    -H "Authorization: Bearer $TOKEN"
+
+# Test DELETE /todos/{id}
+curl -f -X DELETE http://localhost:8080/todos/$ID \
+    -H "Authorization: Bearer $TOKEN"
+
+echo "All API endpoints tested successfully."
+


### PR DESCRIPTION
## Summary
- update build/run scripts to use stricter bash options and cleanup
- add `ci_cd.sh` for simple API integration testing with curl

## Testing
- `cargo check` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_6845a2cc70048326b8f0d8cc5bd713c0