### PR TITLE
Add protected todos route and update redirects

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -19,14 +19,18 @@ export default function App() {
     <Routes>
       <Route
         path="/login"
-        element={isAuthenticated ? <Navigate to="/" replace /> : <LoginPage />}
+        element={isAuthenticated ? <Navigate to="/todos" replace /> : <LoginPage />}
       />
       <Route
         path="/register"
-        element={isAuthenticated ? <Navigate to="/" replace /> : <RegisterPage />}
+        element={isAuthenticated ? <Navigate to="/todos" replace /> : <RegisterPage />}
       />
       <Route
         path="/"
+        element={<Navigate to={isAuthenticated ? '/todos' : '/login'} replace />}
+      />
+      <Route
+        path="/todos"
         element={(
           <PrivateRoute>
             <TodoPage />
@@ -35,7 +39,7 @@ export default function App() {
       />
       <Route
         path="*"
-        element={<Navigate to={isAuthenticated ? '/' : '/login'} replace />}
+        element={<Navigate to={isAuthenticated ? '/todos' : '/login'} replace />}
       />
     </Routes>
   );


### PR DESCRIPTION
## Summary
- add a dedicated protected `/todos` route that renders `TodoPage`
- redirect the root and wildcard routes so authenticated users land on `/todos`
- keep login/register pages redirecting to `/todos` once authenticated

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce484b29bc832696fae7002b143a9d